### PR TITLE
Switch to the old build system so that cordova can continue to work

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,0 +1,9 @@
+{
+  "ios": {
+    "release": {
+      "buildFlag": [
+        "-UseModernBuildSystem=0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is the e-mission-devapp equivalent of
https://github.com/e-mission/e-mission-base/pull/13
https://github.com/e-mission/e-mission-phone/pull/513

It works with both the command line and the xcode UI

```
Prepare build
note: Using legacy build system

=== BUILD TARGET Base64 OF PROJECT Pods WITH CONFIGURATION Debug ===

Check dependencies
...
    /usr/bin/codesign --force --sign - --entitlements /Users/shankari/Library/Developer/Xcode/DerivedData/em-devapp-aalxntodmqcotqduuhtdrmrxfjfc/Build/Intermediates.noindex/em-devapp.build/Debug-iphonesimulator/em-devapp.build/em-devapp.app.xcent --timestamp=none /Users/shankari/e-mission/e-mission-devapp/platforms/ios/build/emulator/em-devapp.app

** BUILD SUCCEEDED **
```

Now I only need to determine why this workaround does not work for the phone