### PR TITLE
Construct all the server call URLs using string concatenation

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="46" id="edu.berkeley.eecs.emission" ios-CFBundleVersion="44" version="3.2.3" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="47" id="edu.berkeley.eecs.emission" ios-CFBundleVersion="45" version="3.2.4" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>em-devapp</name>
     <description>
         The emission Developer app is a clone of the PhoneGap Developer app with the emission plugins. It is a testing utility for web developers and designers using the emission platform. After installing this app on your device or simulator you will be able to use phonegap serve to autorefresh without re-deploying the app everytime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,16 +2765,19 @@
       "from": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.6.5"
     },
     "cordova-plugin-em-server-communication": {
-      "version": "git+https://github.com/e-mission/cordova-server-communication.git#95661c83db23bbcef7dad8ecfe857e1bbbc63c83",
-      "from": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.3"
+      "version": "git+https://github.com/e-mission/cordova-server-communication.git#baa28eed40a6056c233ad08a0e8e0ccdde1d0ef6",
+      "from": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.4",
+      "dev": true
     },
     "cordova-plugin-em-serversync": {
-      "version": "git+https://github.com/e-mission/cordova-server-sync.git#7697415cfe2496e01ee71d78502fd1ff3bfb24d8",
-      "from": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.8"
+      "version": "git+https://github.com/e-mission/cordova-server-sync.git#71ca9bad47f9a98f06f39a20167270911e9993b7",
+      "from": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.9",
+      "dev": true
     },
     "cordova-plugin-em-settings": {
-      "version": "git+https://github.com/e-mission/cordova-connection-settings.git#b936f6fbad37405493b56fbd14cec3a1d8a75740",
-      "from": "git+https://github.com/e-mission/cordova-connection-settings.git#v1.2.2"
+      "version": "git+https://github.com/e-mission/cordova-connection-settings.git#df2e225b994cbd0f13d0c21b1e79bf219f8c1a13",
+      "from": "git+https://github.com/e-mission/cordova-connection-settings.git#v1.2.3",
+      "dev": true
     },
     "cordova-plugin-em-transition-notify": {
       "version": "git+https://github.com/e-mission/e-mission-transition-notify.git#3265eff34e0dad469d54d3f587f3479b8328c586",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phonegap-app-developer",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "PhoneGap Developer app.",
   "homepage": "http://app.phonegap.com",
   "repository": {
@@ -106,9 +106,9 @@
     "cordova-plugin-device": "2.0.3",
     "cordova-plugin-em-datacollection": "git+https://github.com/e-mission/e-mission-data-collection.git#v1.7.2",
     "cordova-plugin-em-jwt-auth": "git+https://github.com/e-mission/cordova-jwt-auth.git#v1.6.5",
-    "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.3",
-    "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.8",
-    "cordova-plugin-em-settings": "git+https://github.com/e-mission/cordova-connection-settings.git#v1.2.2",
+    "cordova-plugin-em-server-communication": "git+https://github.com/e-mission/cordova-server-communication.git#v1.2.4",
+    "cordova-plugin-em-serversync": "git+https://github.com/e-mission/cordova-server-sync.git#v1.2.9",
+    "cordova-plugin-em-settings": "git+https://github.com/e-mission/cordova-connection-settings.git#v1.2.3",
     "cordova-plugin-em-transition-notify": "git+https://github.com/e-mission/e-mission-transition-notify.git#v1.2.7",
     "cordova-plugin-em-unifiedlogger": "git+https://github.com/e-mission/cordova-unified-logger.git#v1.3.5",
     "cordova-plugin-em-usercache": "git+https://github.com/e-mission/cordova-usercache.git#v1.1.5",


### PR DESCRIPTION
Instead on the relativeURL method.

This is because the relative URL appraoch does not work on iOS even though the documentation says that it should

Relative URL doesn't work: https://github.com/e-mission/e-mission-docs/issues/732 (comment)
Appending strings does work: https://github.com/e-mission/e-mission-docs/issues/732 (comment)

Related updates:
- https://github.com/e-mission/cordova-connection-settings/releases/tag/v1.2.3
- https://github.com/e-mission/cordova-server-communication/releases/tag/v1.2.4